### PR TITLE
Re-use unit tests for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,12 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: generate fmt vet manifests
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.0/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -tags test -coverprofile cover.out
+
+# Run e2e tests
+.PHONY: e2e-test
+e2e-test:
+	go test ./e2e  -ginkgo.v -test.v
 
 # Build manager binary
 manager: generate fmt vet
@@ -130,3 +135,12 @@ docker-all: bundle bundle-build bundle-push docker-build docker-push
 # Run unit tests on CI. Nothing special to do for now, but let's be prepared.
 .PHONY: ci-test
 ci-test: test
+
+# Run linter tests on CI. Nothing special to do for now, but let's be prepared.
+.PHONY: ci-lint
+ci-lint:
+	@echo "not implemented yet"
+
+# Run e2e tests on CI. Nothing special to do for now, but let's be prepared.
+.PHONY: ci-e2e-test
+ci-e2e-test: e2e-test

--- a/api/tests/nodes_webhook.go
+++ b/api/tests/nodes_webhook.go
@@ -1,4 +1,4 @@
-package api
+package tests
 
 import (
 	"context"
@@ -15,6 +15,9 @@ import (
 	. "github.com/openshift-kni/node-label-operator/pkg/test"
 )
 
+// Note: this file hasn't the _test.go postfix because it is reused by e2e tests,
+// and _test.go files are only compiled if their own package is under test.
+
 var _ = Describe("Nodes webhook", func() {
 
 	When("Creating a node", func() {
@@ -22,13 +25,17 @@ var _ = Describe("Nodes webhook", func() {
 		var nodeNotMatching *v1.Node
 		var nodeMatching *v1.Node
 		var labels *v1beta1.Labels
+		var k8sClient client.Client
 
 		BeforeEach(func() {
+
+			k8sClient = *K8sClient // from test package
+
 			// Order matters!
 			// And it is important Labels exists for sure before nodes are created
 			By("Creating a Labels CR")
 			labels = GetLabels()
-			Expect(k8sClient.Create(ctx, labels)).Should(Succeed(), "labels should have been created")
+			Expect(k8sClient.Create(context.Background(), labels)).Should(Succeed(), "labels should have been created")
 			Eventually(func() error {
 				return k8sClient.Get(context.Background(), client.ObjectKeyFromObject(labels), labels)
 			}, Timeout, Interval).Should(Succeed(), "labels should exist")

--- a/api/webhook_suite_test.go
+++ b/api/webhook_suite_test.go
@@ -40,7 +40,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/openshift-kni/node-label-operator/api/v1beta1"
-	// +kubebuilder:scaffold:imports
+	"github.com/openshift-kni/node-label-operator/pkg/test"
+
+	// import actual tests
+	// they are in their own package without _test.go prefix
+	// - in order to be reusable by e2e tests
+	// - not influence coverage of this package
+	_ "github.com/openshift-kni/node-label-operator/api/tests"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -128,6 +134,8 @@ var _ = BeforeSuite(func() {
 		conn.Close()
 		return nil
 	}).Should(Succeed())
+
+	test.K8sClient = &k8sClient
 
 }, 60)
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -18,13 +18,14 @@ package controllers
 
 import (
 	"path/filepath"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
@@ -32,7 +33,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/openshift-kni/node-label-operator/api/v1beta1"
-	// +kubebuilder:scaffold:imports
+	"github.com/openshift-kni/node-label-operator/pkg/test"
+
+	// import actual tests
+	// they are in their own package without _test.go prefix
+	// - in order to be reusable by e2e tests
+	// - not influence coverage of this package
+	_ "github.com/openshift-kni/node-label-operator/controllers/tests"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -42,7 +49,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 
-func TestAPIs(t *testing.T) {
+func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecsWithDefaultAndCustomReporters(t,
@@ -91,6 +98,8 @@ var _ = BeforeSuite(func(done Done) {
 
 	k8sClient = k8sManager.GetClient()
 	Expect(k8sClient).ToNot(BeNil())
+
+	test.K8sClient = &k8sClient
 
 	close(done)
 

--- a/controllers/tests/labels_controller.go
+++ b/controllers/tests/labels_controller.go
@@ -1,4 +1,4 @@
-package controllers
+package tests
 
 import (
 	"context"
@@ -16,14 +16,21 @@ import (
 	. "github.com/openshift-kni/node-label-operator/pkg/test"
 )
 
+// Note: this file hasn't the _test.go postfix because it is reused by e2e tests,
+// and _test.go files are only compiled if their own package is under test.
+
 var _ = Describe("Labels controller", func() {
 
 	var nodeNotMatching *v1.Node
 	var nodeMatching *v1.Node
 	var labels *v1beta1.Labels
 	var labelsDeletedByTest bool
+	var k8sClient client.Client
 
 	BeforeEach(func() {
+
+		k8sClient = *K8sClient // from test package
+
 		labelsDeletedByTest = false
 
 		By("Creating nodes")

--- a/controllers/tests/ownedlabels_controller.go
+++ b/controllers/tests/ownedlabels_controller.go
@@ -1,4 +1,4 @@
-package controllers
+package tests
 
 import (
 	"context"
@@ -15,13 +15,20 @@ import (
 	. "github.com/openshift-kni/node-label-operator/pkg/test"
 )
 
+// Note: this file hasn't the _test.go postfix because it is reused by e2e tests,
+// and _test.go files are only compiled if their own package is under test.
+
 var _ = Describe("OwnedLabels controller", func() {
 
 	var nodeMatching *v1.Node
 	var labels *v1beta1.Labels
 	var labelsDeletedByTest bool
+	var k8sClient client.Client
 
 	BeforeEach(func() {
+
+		k8sClient = *K8sClient // from test package
+
 		labelsDeletedByTest = false
 
 		By("Creating nodes")

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -1,0 +1,59 @@
+// +build !test
+
+package e2e
+
+import (
+	"github.com/openshift-kni/node-label-operator/pkg/test"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/openshift-kni/node-label-operator/api/v1beta1"
+
+	// import for running their tests
+	_ "github.com/openshift-kni/node-label-operator/api/tests"
+	_ "github.com/openshift-kni/node-label-operator/controllers/tests"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var cfg *rest.Config
+var k8sClient client.Client
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"E2E Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	err := v1beta1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	cfg, err := config.GetConfig()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	k8sClient, err := client.New(cfg, client.Options{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).ToNot(BeNil())
+
+	test.K8sClient = &k8sClient
+
+	close(done)
+
+}, 60)

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -1,12 +1,12 @@
 package test
 
 import (
-	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift-kni/node-label-operator/api/v1beta1"
 )
@@ -32,9 +32,9 @@ var (
 	Label         = map[string]string{LabelDomainName: LabelValue}
 	LabelNewValue = map[string]string{LabelDomainName: LabelValueNew}
 	LabelNewName  = map[string]string{LabelDomainNameNew: LabelValue}
-)
 
-var ctx = context.Background()
+	K8sClient *client.Client
+)
 
 func GetNode(name string) *v1.Node {
 	return &v1.Node{


### PR DESCRIPTION
This is done by:
- create e2e package with "!test" build flag (will be excluded in "make test" using that flag)
- remove _test postfix from test files, otherwise they are not available for the e2e test package
- move test files into their own package for not falsifying test coverage of the package under test
- import new test packages in their unit test and in the e2e test

Signed-off-by: Marc Sluiter <msluiter@redhat.com>