### PR TITLE
Fix e2e test

### DIFF
--- a/controllers/tests/labels_controller.go
+++ b/controllers/tests/labels_controller.go
@@ -30,24 +30,23 @@ var _ = Describe("Labels controller", func() {
 	BeforeEach(func() {
 
 		k8sClient = *K8sClient // from test package
-
 		labelsDeletedByTest = false
 
-		By("Creating nodes")
-		nodeNotMatching = GetNode(NodeNameNoMatch)
-		Expect(k8sClient.Create(context.Background(), nodeNotMatching)).Should(Succeed(), "nodeNotMatching should have been created")
-		nodeMatching = GetNode(NodeNameMatching)
-		Expect(k8sClient.Create(context.Background(), nodeMatching)).Should(Succeed(), "nodeMatching should have been created")
+		nodes := FindWorkerNodes()
+		nodeMatching = nodes[0]
+		nodeNotMatching = nodes[1]
 
 		By("Creating a Labels CR")
-		labels = GetLabels()
+		nodeNamePattern := GetPattern(nodeMatching.Name, nodeNotMatching.Name)
+		labels = GetLabels(nodeNamePattern)
 		Expect(k8sClient.Create(context.Background(), labels)).Should(Succeed(), "labels should have been created")
+
 	})
 
 	AfterEach(func() {
 		By("Cleaning up nodes and labels")
-		Expect(k8sClient.Delete(context.Background(), nodeNotMatching)).Should(Succeed(), "nodeNotMatching should have been deleted")
-		Expect(k8sClient.Delete(context.Background(), nodeMatching)).Should(Succeed(), "nodeMatching should have been deleted")
+		CleanupDummyNodes()
+
 		if !labelsDeletedByTest {
 			Expect(k8sClient.Delete(context.Background(), labels)).Should(Succeed(), "labels should have been deleted")
 			Eventually(func() bool {

--- a/controllers/tests/ownedlabels_controller.go
+++ b/controllers/tests/ownedlabels_controller.go
@@ -28,21 +28,21 @@ var _ = Describe("OwnedLabels controller", func() {
 	BeforeEach(func() {
 
 		k8sClient = *K8sClient // from test package
-
 		labelsDeletedByTest = false
 
-		By("Creating nodes")
-		nodeMatching = GetNode(NodeNameMatching)
-		Expect(k8sClient.Create(context.Background(), nodeMatching)).Should(Succeed(), "nodeMatching should have been created")
+		nodes := FindWorkerNodes()
+		nodeMatching = nodes[0]
 
 		By("Creating a Labels CR")
-		labels = GetLabels()
+		nodeNamePattern := GetPattern(nodeMatching.Name, "")
+		labels = GetLabels(nodeNamePattern)
 		Expect(k8sClient.Create(context.Background(), labels)).Should(Succeed(), "labels should have been created")
 	})
 
 	AfterEach(func() {
 		By("Cleaning up nodes and labels")
-		Expect(k8sClient.Delete(context.Background(), nodeMatching)).Should(Succeed(), "nodeMatching should have been deleted")
+		CleanupDummyNodes()
+
 		if !labelsDeletedByTest {
 			Expect(k8sClient.Delete(context.Background(), labels)).Should(Succeed(), "labels should have been deleted")
 			By("Ensure Labels is deleted")

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -53,6 +53,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(k8sClient).ToNot(BeNil())
 
 	test.K8sClient = &k8sClient
+	test.IsE2etest = true
 
 	close(done)
 


### PR DESCRIPTION
Dummy nodes are deleted quite quickly by the cluster.
so for the webhook test use a finalizer to be able to check if labels were added, and for the controller tests use exiting nodes.