### PR TITLE
Print some version info on operator start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,27 +2,18 @@
 FROM golang:1.15 as builder
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
 
-# Copy the go source
-COPY main.go main.go
-COPY api/ api/
-COPY controllers/ controllers/
-COPY pkg/ pkg/
+# Copy all sources
+COPY . .
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN make manager
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/bin/manager .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ e2e-test:
 
 # Build manager binary
 manager: generate fmt vet
-	go build -o bin/manager main.go
+	hack/build.sh
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -ex
+
+GIT_VERSION=$(git describe --always --tags || true)
+VERSION=${CI_UPSTREAM_VERSION:-${GIT_VERSION}}
+GIT_COMMIT=$(git rev-list -1 HEAD || true)
+COMMIT=${CI_UPSTREAM_COMMIT:-${GIT_COMMIT}}
+BUILD_DATE=$(date --utc -Iseconds)
+
+mkdir -p bin
+
+LDFLAGS="-s -w "
+LDFLAGS+="-X github.com/openshift-kni/node-label-operator/pkg.Version=${VERSION} "
+LDFLAGS+="-X github.com/openshift-kni/node-label-operator/pkg.GitCommit=${COMMIT} "
+LDFLAGS+="-X github.com/openshift-kni/node-label-operator/pkg.BuildDate=${BUILD_DATE} "
+GOFLAGS=-mod=vendor CGO_ENABLED=0 GOOS=linux go build -ldflags="${LDFLAGS}" -o bin/manager github.com/openshift-kni/node-label-operator

--- a/main.go
+++ b/main.go
@@ -18,14 +18,16 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
-	"k8s.io/apimachinery/pkg/runtime"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -36,11 +38,12 @@ import (
 	"github.com/openshift-kni/node-label-operator/api"
 	nodelabelsv1beta1 "github.com/openshift-kni/node-label-operator/api/v1beta1"
 	"github.com/openshift-kni/node-label-operator/controllers"
+	"github.com/openshift-kni/node-label-operator/pkg"
 	// +kubebuilder:scaffold:imports
 )
 
 var (
-	scheme   = runtime.NewScheme()
+	scheme   = k8sruntime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 )
 
@@ -67,6 +70,8 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	printVersion()
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
@@ -148,4 +153,12 @@ func setupExternalResourcesWebhooks(mgr manager.Manager) error {
 
 	return nil
 
+}
+
+func printVersion() {
+	setupLog.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
+	setupLog.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
+	setupLog.Info(fmt.Sprintf("Operator Version: %s", pkg.Version))
+	setupLog.Info(fmt.Sprintf("Git Commit: %s", pkg.GitCommit))
+	setupLog.Info(fmt.Sprintf("Build Date: %s", pkg.BuildDate))
 }

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -1,0 +1,10 @@
+package pkg
+
+var (
+	// Version is the operator version
+	Version = "0.0.1"
+	// GitCommit is the current git commit hash
+	GitCommit = "n/a"
+	// BuildDate is the build date
+	BuildDate = "n/a"
+)


### PR DESCRIPTION
Example output:

```
$ docker run quay.io/openshift-kni/node-label-operator:v0.1.0
2021-03-30T15:26:00.612Z        INFO    setup   Go Version: go1.15.6
2021-03-30T15:26:00.612Z        INFO    setup   Go OS/Arch: linux/amd64
2021-03-30T15:26:00.612Z        INFO    setup   Operator Version: 00bf94d
2021-03-30T15:26:00.612Z        INFO    setup   Git Commit: 00bf94dd3f52a78d7a21426334837ac90427f7d0
2021-03-30T15:26:00.612Z        INFO    setup   Build Date: 2021-03-30T15:24:29+00:00
```
Operator version will print tag info as soom as we have a git tag set 